### PR TITLE
LambdaにバックエンドをデプロイするGitHub Actionsのワークフローを追加し、Lambda関数を作成

### DIFF
--- a/.github/workflows/back_deploy.yml
+++ b/.github/workflows/back_deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy back on Lambda
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "back/**"
+
+jobs:
+  deploy_on_lambda:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    name: Deploy on Lambda
+    steps:
+      # main ブランチを取得する
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # zip化する
+      - name: Zip
+        run: zip -r test-func.zip test-func
+        working-directory: ./back
+
+      # AWSへ接続する
+      - name: Assuming AWS role with OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: "ap-northeast-1" # リージョンを指定
+          role-to-assume: "arn:aws:iam::851725478795:role/mapapp-iam-github-role" # 作成した IAM ロールの ARN
+
+      # デプロイする
+      - name: Deploy
+        run: aws lambda update-function-code --function-name test-func --zip-file fileb://test-func.zip
+        working-directory: ./back

--- a/back/test-func/index.mjs
+++ b/back/test-func/index.mjs
@@ -1,0 +1,8 @@
+export const handler = async (event) => {
+  // TODO implement
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify("Hello from Lambda!"),
+  };
+  return response;
+};


### PR DESCRIPTION
.github/workflows/back_deploy.yml
- LambdaにバックエンドをデプロイするためのGitHub Actionsワークフローを追加
- mainブランチへのpush時に実行されるよう設定
- backディレクトリ内のファイルが変更された場合に実行されるよう設定
- AWS Lambdaにデプロイするためのステップを追加

back/test-func/index.mjs
- Lambda関数のハンドラを定義
- レスポンスとして"Hello from Lambda!"というメッセージを返す