### PR TITLE
バックエンドのデプロイ設定を更新し、新しいLambda関数を追加、既存のLambda関数を更新

### DIFF
--- a/.github/workflows/back_deploy.yml
+++ b/.github/workflows/back_deploy.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # zip化する
-      - name: Zip
-        run: zip -r test-func.zip test-func
-        working-directory: ./back
-
       # AWSへ接続する
       - name: Assuming AWS role with OIDC
         uses: aws-actions/configure-aws-credentials@v4
@@ -31,7 +26,22 @@ jobs:
           aws-region: "ap-northeast-1" # リージョンを指定
           role-to-assume: "arn:aws:iam::851725478795:role/mapapp-iam-github-role" # 作成した IAM ロールの ARN
 
-      # デプロイする
+      # mapapp-func-get zip化
+      - name: Zip
+        run: zip -r deploy.zip ./index.mjs
+        working-directory: ./back/mapapp-func-get
+
+      # mapapp-func-get デプロイ
       - name: Deploy
-        run: aws lambda update-function-code --function-name test-func --zip-file fileb://test-func.zip
-        working-directory: ./back
+        run: aws lambda update-function-code --function-name mapapp-func-get --zip-file fileb://deploy.zip
+        working-directory: ./back/mapapp-func-get
+
+      # mapapp-func-websocket zip化
+      - name: Zip
+        run: zip -r deploy.zip ./index.mjs
+        working-directory: ./back/mapapp-func-websocket
+
+      # mapapp-func-websocket デプロイ
+      - name: Deploy
+        run: aws lambda update-function-code --function-name mapapp-func-websocket --zip-file fileb://deploy.zip
+        working-directory: ./back/mapapp-func-websocket

--- a/back/mapapp-func-get/index.mjs
+++ b/back/mapapp-func-get/index.mjs
@@ -1,0 +1,35 @@
+import { DynamoDBClient, ScanCommand } from "@aws-sdk/client-dynamodb";
+
+const client = new DynamoDBClient({});
+
+const scanTable = async () => {
+  const command = new ScanCommand({
+    TableName: "mapapp-db",
+  });
+  const data = await client.send(command);
+  return data.Items;
+};
+
+export const handler = async (event) => {
+  try {
+    const items = await scanTable();
+    const response = {
+      statusCode: 200,
+      body: JSON.stringify(items),
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+    };
+    return response;
+  } catch (error) {
+    console.error("Error scanning table:", error);
+    const response = {
+      statusCode: 500,
+      body: JSON.stringify({ message: "Internal Server Error" }),
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+    };
+    return response;
+  }
+};

--- a/back/mapapp-func-websocket/index.mjs
+++ b/back/mapapp-func-websocket/index.mjs
@@ -2,7 +2,7 @@ export const handler = async (event) => {
   // TODO implement
   const response = {
     statusCode: 200,
-    body: JSON.stringify("Hello from Lambda!"),
+    body: JSON.stringify("Hello from Lambda?"),
   };
   return response;
 };


### PR DESCRIPTION
.github/workflows/back_deploy.yml
- test-funcのzip化とデプロイのジョブを削除
- mapapp-func-getとmapapp-func-websocketのzip化とデプロイのジョブを追加

back/mapapp-func-get/index.mjs
- DynamoDBClientとScanCommandをインポート
- scanTable関数を定義し、テーブルをスキャンしてデータを取得する
- handler関数を定義し、テーブルをスキャンして取得したデータを返す

back/mapapp-func-websocket/index.mjs
- handler関数内の返り値を"Hello from Lambda?"に変更

back/test-func/deploy.zip
- 削除