### PR TITLE
バックエンドデプロイのワークフローのジョブ名を変更

### DIFF
--- a/.github/workflows/back_deploy.yml
+++ b/.github/workflows/back_deploy.yml
@@ -27,21 +27,21 @@ jobs:
           role-to-assume: "arn:aws:iam::851725478795:role/mapapp-iam-github-role" # 作成した IAM ロールの ARN
 
       # mapapp-func-get zip化
-      - name: Zip
+      - name: mapapp-func-get zip
         run: zip -r deploy.zip ./index.mjs
         working-directory: ./back/mapapp-func-get
 
       # mapapp-func-get デプロイ
-      - name: Deploy
+      - name: mapapp-func-get deploy
         run: aws lambda update-function-code --function-name mapapp-func-get --zip-file fileb://deploy.zip
         working-directory: ./back/mapapp-func-get
 
       # mapapp-func-websocket zip化
-      - name: Zip
+      - name: mapapp-func-websocket zip
         run: zip -r deploy.zip ./index.mjs
         working-directory: ./back/mapapp-func-websocket
 
       # mapapp-func-websocket デプロイ
-      - name: Deploy
+      - name: mapapp-func-websocket deploy
         run: aws lambda update-function-code --function-name mapapp-func-websocket --zip-file fileb://deploy.zip
         working-directory: ./back/mapapp-func-websocket


### PR DESCRIPTION
.github/workflows/back_deploy.yml
- mapapp-func-get zipのジョブ名をZipからmapapp-func-get zipに変更
- mapapp-func-get deployのジョブ名をDeployからmapapp-func-get deployに変更
- mapapp-func-websocket zipのジョブ名をZipからmapapp-func-websocket zipに変更
- mapapp-func-websocket deployのジョブ名をDeployからmapapp-func-websocket deployに変更