### PR TITLE
DynamoDBを操作するための処理を追加し、レコードのconnection_idsを更新するように修正

### DIFF
--- a/back/mapapp-func-websocket/index.mjs
+++ b/back/mapapp-func-websocket/index.mjs
@@ -1,8 +1,35 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { PutCommand, DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+
 export const handler = async (event) => {
-  // TODO implement
-  const response = {
+  const client = new DynamoDBClient({});
+  const docClient = DynamoDBDocumentClient.from(client);
+
+  const getCommand = new GetCommand({
+    TableName: "mapapp-db",
+    Key: {
+      id: 1,
+    },
+  });
+
+  const response = await docClient.send(getCommand);
+  const connectionId = event.requestContext.connectionId;
+
+  let connectionIds = response.Item.connection_ids;
+
+  connectionIds.push(connectionId);
+
+  const putCommand = new PutCommand({
+    TableName: "message_rooms",
+    Item: {
+      ...response.Item,
+      connection_ids: connectionIds,
+    },
+  });
+
+  await docClient.send(putCommand);
+
+  return {
     statusCode: 200,
-    body: JSON.stringify("Hello from Lambda?"),
   };
-  return response;
 };


### PR DESCRIPTION
back/mapapp-func-websocket/index.mjs
- DynamoDBClientとDynamoDBDocumentClientをインポート
- handler関数内でDynamoDBClientを使用してDynamoDBDocumentClientを作成
- GetCommandを使用して指定したidのレコードを取得し、connection_idsを更新
- PutCommandを使用して更新したレコードを保存
- レスポンスの返り値を修正し、更新後のレコードを返す